### PR TITLE
Allow copying texts with newlines

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function available() {
  * });
  */
 function copy(text) {
-  var fakeElem = document.body.appendChild(document.createElement('input'));
+  var fakeElem = document.body.appendChild(document.createElement('textarea'));
   fakeElem.style.position = 'absolute';
   fakeElem.style.left = '-9999px';
   fakeElem.setAttribute('readonly', '');


### PR DESCRIPTION
`input` elements don't allow copying newlines. A `textarea` can solve this. LMK what you think!